### PR TITLE
feat: modificacion de modelo y nuevos controladores para agregar titu…

### DIFF
--- a/models/userModel.js
+++ b/models/userModel.js
@@ -41,7 +41,8 @@ const UserSchema = new Schema(
     last_ride: { type: Schema.Types.ObjectId, ref: 'Ride' },
     frequent_routes: { type: Array },
     isVerify: { type: Boolean },
-    temporalCode: { type: Number }
+    temporalCode: { type: Number },
+    titles: [ String ]
 
   }, {
     timestamps: true

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -8,6 +8,8 @@ router.get("/", userController.getUserInformation);
 // POSTs
 router.post("/", userController.create);
 router.post("/code", userController.codeValidate);
+router.post("/add_title", userController.addTitle);
+router.post("/remove_title", userController.removeTitle);
 
 // PUTs
 router.put("/", userController.updateUser);


### PR DESCRIPTION
## Endpoints para títulos honoríficos
- Se modificó el modelo de usuarios para incluir un nuevo campo: "titles". Este campo en un arreglo de strings en el que se guardan los títulos asignados al usuario
- Se agregaron dos nuevos controladores para agregar y eliminar un titulo del arreglo de titulos
- Se agregaron dos nuevos endpoints para exponer los controladores bajo las urls: `/users/remove_title` y `/users/add_title`

### Pruebas:
 Se ejecutaron pruebas en Postman para garantizar el funcionamiento de la nueva funcionalidad
 
 ### Notas
 La api actualmente es pública debido a que no se tiene implementado un sistema de roles en la aplicación. Por ello, cualquier usuario es capaz de asignar titulos a cualquier otro usuario hasta que se implementen los roles.
